### PR TITLE
Normalize images loaded from storage

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -285,6 +285,9 @@ class BaseHandler(tornado.web.RequestHandler):
 
                 return
 
+            if not normalized:
+                normalized = self.context.request.engine.normalize()
+
         self.context.transformer = Transformer(self.context)
 
         await self.filters_runner.apply_filters(


### PR DESCRIPTION
Images loaded from backend are normalized, but when loaded from storage, they are not. This PR makes sure the normalization happens for those images as well.