### PR TITLE
Extend context with custom_result_storage_name

### DIFF
--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -171,6 +171,7 @@ class RequestParameters:  # pylint: disable=too-few-public-methods,too-many-inst
         request=None,
         max_age=None,
         auto_png_to_jpg=None,
+        custom_result_storage_name=None,
     ):
         self.debug = bool(debug)
         self.meta = bool(meta)
@@ -238,6 +239,7 @@ class RequestParameters:  # pylint: disable=too-few-public-methods,too-many-inst
         self.max_age = max_age
         self.auto_png_to_jpg = auto_png_to_jpg
         self.headers = None
+        self.custom_result_storage_name = custom_result_storage_name
 
         if request:
             self.url = request.path

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -32,7 +32,8 @@ class Storage(BaseStorage):
         )
 
     async def put(self, image_bytes):
-        file_abspath = self.normalize_path(self.context.request.url)
+        path = self.get_path()
+        file_abspath = self.normalize_path(path)
         if not self.validate_path(file_abspath):
             logger.warning(
                 "[RESULT_STORAGE] unable to write outside root path: %s",
@@ -55,7 +56,7 @@ class Storage(BaseStorage):
         move(temp_abspath, file_abspath)
 
     async def get(self):
-        path = self.context.request.url
+        path = self.get_path()
         file_abspath = self.normalize_path(path)
 
         if not self.validate_path(file_abspath):
@@ -156,9 +157,15 @@ class Storage(BaseStorage):
         timediff = datetime.now() - datetime.fromtimestamp(getmtime(path))
         return timediff.total_seconds() > expire_in_seconds
 
+    def get_path(self):
+        if self.context.custom_result_storage_name is not None:
+            return self.context.custom_result_storage_name
+        return self.context.request.url
+
+
     @deprecated("Use result's last_modified instead")
     def last_updated(self):
-        path = self.context.request.url
+        path = self.get_path()
         file_abspath = self.normalize_path(path)
         if not self.validate_path(file_abspath):
             logger.warning(


### PR DESCRIPTION
The custom_result_storage_name can be set by handlers wishing to control the name of the file when storing to result storage. This can be useful if for example the handler accepts formatting through query string parameters, that are otherwise ignored when saving the result.